### PR TITLE
Fix the pip install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages =
     fms_yaml_tools/data_table
     fms_yaml_tools/diag_table
     fms_yaml_tools/field_table
+    fms_yaml_tools
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Add the top `fms_yaml_tools` folder to the packages to prevent issues when pip installing.

Fixes #23 