### PR TITLE
Bettereliminatesubparams

### DIFF
--- a/fms_yaml_tools/field_table/field_table_to_yaml.py
+++ b/fms_yaml_tools/field_table/field_table_to_yaml.py
@@ -70,7 +70,6 @@ class Field:
     self.field_type = in_field_type
     self.name = entry_tuple[0]
     self.dict = OrderedDict()
-    self.num_subparams = 0
     for in_prop in entry_tuple[1]:
       if 'tracer' == self.field_type:
         self.process_tracer(in_prop)
@@ -113,10 +112,8 @@ class Field:
     """ Process a tracer field """
     if args.verbose:
       print(len(prop))
-    self.dict[prop[0]] = prop[1]
+    self.dict[prop[0]] = [OrderedDict([('value', prop[1])])]
     if len(prop) > 2:
-      self.dict[f'subparams{str(self.num_subparams)}'] = [OrderedDict()] 
-      self.num_subparams += 1
       if args.verbose:
         print(self.name)
         print(self.field_type)
@@ -124,16 +121,16 @@ class Field:
       for sub_param in prop[2:]:
         eq_split = sub_param.split('=')
         if len(eq_split) < 2:
-          self.dict[prop[0]] = 'fm_yaml_null'
+          self.dict[prop[0]][0]['value'] = 'fm_yaml_null'
           val = dont_convert_yaml_val(eq_split[0])
           if isinstance(val, list):
             val = [dont_convert_yaml_val(b) for b in val]
-          self.dict[f'subparams{str(self.num_subparams-1)}'][0][prop[1].strip()] = val
+          self.dict[prop[0]][0][prop[1].strip()] = val
         else:
           val = dont_convert_yaml_val(eq_split[-1])
           if isinstance(val, list):
             val = [dont_convert_yaml_val(b) for b in val]
-          self.dict[f'subparams{str(self.num_subparams-1)}'][0][eq_split[0].strip()] = val
+          self.dict[prop[0]][0][eq_split[0].strip()] = val
       
 def list_items(brief_text, brief_od):
   """ Given text and an OrderedDict, make an OrderedDict and convert to list """

--- a/fms_yaml_tools/field_table/field_table_to_yaml.py
+++ b/fms_yaml_tools/field_table/field_table_to_yaml.py
@@ -249,9 +249,8 @@ class FieldYaml:
   def writeyaml(self):
     """ Write yaml out to file """
     raw_out = yaml.dump(self.lists_wh_yaml, None, default_flow_style=False)
-    final_out = re.sub('subparams\d*:','subparams:',raw_out)
     with open(f'{self.filename}.yaml', 'w') as yaml_file:
-      yaml_file.write(final_out)
+      yaml_file.write(raw_out)
 
   def main(self):
     self.init_ordered_keys()

--- a/fms_yaml_tools/field_table/field_table_to_yaml.py
+++ b/fms_yaml_tools/field_table/field_table_to_yaml.py
@@ -112,8 +112,8 @@ class Field:
     """ Process a tracer field """
     if args.verbose:
       print(len(prop))
-    self.dict[prop[0]] = [OrderedDict([('value', prop[1])])]
     if len(prop) > 2:
+      self.dict[prop[0]] = [OrderedDict([('value', prop[1])])]
       if args.verbose:
         print(self.name)
         print(self.field_type)
@@ -131,6 +131,11 @@ class Field:
           if isinstance(val, list):
             val = [dont_convert_yaml_val(b) for b in val]
           self.dict[prop[0]][0][eq_split[0].strip()] = val
+    else:
+      val = dont_convert_yaml_val(prop[1])
+      if isinstance(val, list):
+        val = [dont_convert_yaml_val(b) for b in val]
+      self.dict[prop[0]] = val
       
 def list_items(brief_text, brief_od):
   """ Given text and an OrderedDict, make an OrderedDict and convert to list """


### PR DESCRIPTION
Eliminates the subparams part of the field_table.yaml. Now, any field with associated methods will have those as a subsection of the yaml. Example output:

```
    - variable: omphil
      longname: omphil tracer
      units: mmr
      profile_type:
      - value: fixed
        surface_value: 1.0e-32
      convection: all
      chem_param:
      - value: aerosol
        frac_pm1: 0.89
        frac_pm25: 0.96
        frac_pm10: 1.0 
      dry_deposition:
      - value: wind_driven
        surfr: 100.0
      wet_deposition:
      - value: aerosol_below
        frac_incloud: 0.2 
        frac_incloud_uw: 0.3 
        frac_incloud_donner: 0.3 
        frac_incloud_snow: 0.0 
        alphar: 0.001
        alphas: 0.001
      radiative_param:
      - value: online
        name_in_rad_mod: omphilic
        name_in_clim_mod: organic_carbon

```
