### PR TITLE
Crash if static files don't have none as the reduction method

### DIFF
--- a/fms_yaml_tools/diag_table/diag_table_to_yaml.py
+++ b/fms_yaml_tools/diag_table/diag_table_to_yaml.py
@@ -430,6 +430,7 @@ class DiagTable:
                 ifile_dict['is_ocean'] = True
             ifile_dict['sub_region'] = []
 
+            is_static = ifile_dict['freq_int'] == -1
             # Combine freq_int and freq_units into 1 key
             ifile_dict['freq'] = str(ifile_dict['freq_int']) + ' ' + ifile_dict['freq_units']
             del ifile_dict['freq_int']
@@ -468,6 +469,11 @@ class DiagTable:
             for ifield_dict in self.field_section:  #: field_section = [ {}, {}. {} ]
                 if ifield_dict['file_name'] == ifile_dict['file_name']:
                     tmp_dict = cp.deepcopy(ifield_dict)
+                    if tmp_dict['reduction'] != "none" :
+                        raise Exception ("file " + ifile_dict['file_name'] +
+                          " is a static file, but the variable: " + tmp_dict['output_name'] +
+                          " is using " + tmp_dict['reduction'] + " as its reduction method." +
+                          " The reduction method should be none for a variables in a static file!")
 
                     # Ensure that the output_name contains "min"
                     # if the reduction method is "min"

--- a/fms_yaml_tools/diag_table/diag_table_to_yaml.py
+++ b/fms_yaml_tools/diag_table/diag_table_to_yaml.py
@@ -473,7 +473,7 @@ class DiagTable:
                         raise Exception ("file " + ifile_dict['file_name'] +
                           " is a static file, but the variable: " + tmp_dict['output_name'] +
                           " is using " + tmp_dict['reduction'] + " as its reduction method." +
-                          " The reduction method should be none for a variables in a static file!")
+                          " The reduction method (6th column) should be none for a variables in a static file!")
 
                     # Ensure that the output_name contains "min"
                     # if the reduction method is "min"


### PR DESCRIPTION
The following table
```
 "atmos_static",       -1,  "hours", 1, "days", "time",
 "dynamics",       "lat",      "lat",   "atmos_static", "all", .true., "none", 2
```
will result in the following error message:

```
Exception: file atmos_static is a static file, but the variable: lat is using average as its reduction method. The reduction method (6th column) should be none for a variables in a static file!
```