### PR TITLE
Added clearer error message when combiner script is run with incorrectly formatted yamls

### DIFF
--- a/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
+++ b/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
@@ -116,9 +116,19 @@ def combine_yaml(files):
             raise FileNotFoundError(errno.ENOENT,
                                     strerror(errno.ENOENT),
                                     f)
-
-        with open(f) as fl:
-            my_table = yaml.safe_load(fl)
+	
+        # Verify that yaml is read correctly
+        try:
+            with open(f) as fl:
+                my_table = yaml.safe_load(fl)
+        except yaml.scanner.ScannerError as scanerr:
+            print("ERROR:",scanerr)
+            raise Exception("ERROR: Please verify that the previous entry in the yaml file is entered as "
+			"\"key: value\" and not as \"key:value\" ")
+	
+        if isinstance(my_table,str):
+            raise Exception("ERROR: diagYaml contains incorrectly formatted key value pairs." 
+			" Make sure that entries are formatted as \"key: value\" and not \"key:value\" ")
 
         if 'base_date' in my_table:
             diag_table['base_date'] = my_table['base_date']


### PR DESCRIPTION
This PR addresses issue #54 . It adds a try-except clause to catch yamls that couldn't not be read because they contain a mixture of correctly formatted keys and incorrectly formatted keys, which address the problem that led to the ScannerError described in that issue. It also verifies that pyyaml doesn't read the yaml as a string, which address the "string indices must be integers" problem described in the issue. 