### PR TITLE
fms_yaml_tools conda environment+packaging attempt

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -1,0 +1,25 @@
+name: build_conda
+on:
+  [push]
+#  pull_request:
+#    branches:
+#      - FOOmainBAR
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: continuumio/miniconda3:latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v4
+    - name: Run Conda to Build
+      run: |
+        conda config --append channels conda-forge
+        conda config --append channels noaa-gfdl
+        conda install conda-build conda-verify
+        git submodule update --init --recursive --remote
+        git config --global --add safe.directory fms_yaml_tools/schema/gfdl_msd_schemas
+        rm -rf fms_yaml_tools/schema/gfdl_msd_schemas/.git
+        conda build .
+        ls .

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -1,4 +1,5 @@
 name: build_conda
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -1,9 +1,8 @@
 name: build_conda
 on:
-  [push]
-#  pull_request:
-#    branches:
-#      - FOOmainBAR
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -13,13 +13,11 @@ jobs:
     steps:
     - name: Checkout Files
       uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
     - name: Run Conda to Build
       run: |
         conda config --append channels conda-forge
         conda config --append channels noaa-gfdl
         conda install conda-build conda-verify
-        git submodule update --init --recursive --remote
-        git config --global --add safe.directory fms_yaml_tools/schema/gfdl_msd_schemas
-        rm -rf fms_yaml_tools/schema/gfdl_msd_schemas/.git
         conda build .
-        ls .

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -1,6 +1,6 @@
 name: create_test_conda_env
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -6,35 +6,35 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-	    with:
-		  submodules: 'recursive'
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '>=3.9'
-      
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an env var pointing to root of miniconda dir
-          echo $CONDA/bin >> $GITHUB_PATH
-      
-      - name: Create fms_yaml_tools environment
-        run: |
-          # create environment containing all dependencies
-          # the env cannot be explicitly activated in github CI/CD
-          conda env create -f environment.yml --name fms_yaml_tools
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '>=3.9'
 
-          # add conda env's executables to github's PATH equiv.
-          echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an env var pointing to root of miniconda dir
+        echo $CONDA/bin >> $GITHUB_PATH
 
-          # use *conda environment's pip* to install fms_yaml_tools
-          # called w/ full path to conda's python for explicitness
-          # called as a module (-m pip) for explicitness
-          $CONDA/envs/fms_yaml_tools/bin/python -m pip install --prefix $CONDA/envs/fms_yaml_tools .      
+    - name: Create fms_yaml_tools environment
+      run: |
+        # create environment containing all dependencies
+        # the env cannot be explicitly activated in github CI/CD
+        conda env create -f environment.yml --name fms_yaml_tools
 
-      - name: Run unittest in fms_yaml_tools environment
-        run: |
-          # try to make sure the right things are in GITHUB_PATH
-          echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
-          python -m unittest discover -s test
+        # add conda env's executables to github's PATH equiv.
+        echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
+
+        # use *conda environment's pip* to install fms_yaml_tools
+        # called w/ full path to conda's python for explicitness
+        # called as a module (-m pip) for explicitness
+        $CONDA/envs/fms_yaml_tools/bin/python -m pip install --prefix $CONDA/envs/fms_yaml_tools .
+
+    - name: Run unittest in fms_yaml_tools environment
+      run: |
+        # try to make sure the right things are in GITHUB_PATH
+        echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
+        python -m unittest discover -s test

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -1,0 +1,41 @@
+name: create_test_conda_env
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '>=3.9'
+      
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an env var pointing to root of miniconda dir
+          echo $CONDA/bin >> $GITHUB_PATH
+      
+      - name: Create fms_yaml_tools environment
+        run: |
+          # create environment containing all dependencies
+          # the env cannot be explicitly activated in github CI/CD
+          conda env create -f environment.yml --name fms_yaml_tools
+
+          # add conda env's executables to github's PATH equiv.
+          echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
+
+          # get fms_yaml_tools/schema/gfdl_msd_schemas/FMS for unittest
+          git submodule update --init --recursive --remote
+          
+          # use *conda environment's pip* to install fms_yaml_tools
+          # called w/ full path to conda's python for explicitness
+          # called as a module (-m pip) for explicitness
+          $CONDA/envs/fms_yaml_tools/bin/python -m pip install --prefix $CONDA/envs/fms_yaml_tools .      
+
+      - name: Run unittest in fms_yaml_tools environment
+        run: |
+          # try to make sure the right things are in GITHUB_PATH
+          echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
+          python -m unittest discover -s test

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+	    with:
+		  submodules: 'recursive'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -26,9 +28,6 @@ jobs:
           # add conda env's executables to github's PATH equiv.
           echo $CONDA/envs/fms_yaml_tools/bin >> $GITHUB_PATH
 
-          # get fms_yaml_tools/schema/gfdl_msd_schemas/FMS for unittest
-          git submodule update --init --recursive --remote
-          
           # use *conda environment's pip* to install fms_yaml_tools
           # called w/ full path to conda's python for explicitness
           # called as a module (-m pip) for explicitness

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -1,23 +1,23 @@
 name: publish_conda
 on:
   push:
-	branches:
-	  - main
+    branches:
+      - main
 jobs:
   publish:
-	runs-on: ubuntu-latest
-	container:
-	  image: continuumio/miniconda3:latest
-	steps:
-	  - name: Checkout Files
-		uses: actions/checkout@v4
-		with:
-		  submodules: 'recursive'
-	  - name: Run Conda to Build and Publish
-		run: |
-		  conda config --append channels conda-forge
-		  conda config --append channels noaa-gfdl
-		  conda install conda-build anaconda-client conda-verify
-		  export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
-		  conda config --set anaconda_upload yes
-		  conda build .
+    runs-on: ubuntu-latest
+    container:
+      image: continuumio/miniconda3:latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Run Conda to Build and Publish
+      run: |
+        conda config --append channels conda-forge
+        conda config --append channels noaa-gfdl
+        conda install conda-build anaconda-client conda-verify
+        export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
+        conda config --set anaconda_upload yes
+        conda build .

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -1,8 +1,9 @@
 name: publish_conda
 on:
-  push:
-    branches:
-      - main
+  push
+#    branches:
+#      - main
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -1,0 +1,22 @@
+name: publish_conda
+on:
+  push:
+	branches:
+	  - main
+jobs:
+  publish:
+	runs-on: ubuntu-latest
+	container:
+	  image: continuumio/miniconda3:latest
+	steps:
+	  - name: Checkout Files
+		uses: actions/checkout@v4
+	  - name: Run Conda to Build and Publish
+		run: |
+		  conda config --append channels conda-forge
+		  conda config --append channels noaa-gfdl
+		  conda install conda-build anaconda-client conda-verify
+		  export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
+		  conda config --set anaconda_upload yes
+		  git submodule update --init --recursive --remote
+		  conda build .

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -11,6 +11,8 @@ jobs:
 	steps:
 	  - name: Checkout Files
 		uses: actions/checkout@v4
+		with:
+		  submodules: 'recursive'
 	  - name: Run Conda to Build and Publish
 		run: |
 		  conda config --append channels conda-forge
@@ -18,5 +20,4 @@ jobs:
 		  conda install conda-build anaconda-client conda-verify
 		  export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
 		  conda config --set anaconda_upload yes
-		  git submodule update --init --recursive --remote
 		  conda build .

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -1,6 +1,5 @@
 name: publish_conda
-on:
-  push
+on: [push, pull_request]
 #    branches:
 #      - main
 

--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -11,7 +11,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+	    with:
+		  submodules: 'recursive'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-	    with:
-		  submodules: 'recursive'
+        with:
+          submodules: 'recursive'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: fms_yaml_tools
+channels:
+  - defaults
+  - conda-forge
+  - noaa-gfdl
+dependencies:
+  - python
+  - pip
+  - click
+  - pyyaml
+  - pylint
+  - jsonschema

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: fms_yaml_tools
+  version: 'alpha'
+#  version: '{{ environ.get("GIT_DESCRIBE_TAG", data.get("version")) }}'
+
+source:
+  path: .
+
+build:
+  script: 
+    - python3 -m pip install . -vv
+  number: 1
+  noarch: python
+
+channels:
+    - defaults
+    - conda-forge
+    - noaa-gfdl
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - pip
+    - click
+    - pyyaml
+    - pylint
+    - jsonschema
+
+test:
+  source_files:
+    - fms_yaml_tools/
+  commands:
+    - python -m unittest discover -s test
+
+about:
+  home: https://github.com/NOAA-GFDL/fms_yaml_tools


### PR DESCRIPTION
This is less an actual PR, and more a discussion with some diffs nearby to easily click through. 

There was a [clear and early intention](https://github.com/NOAA-GFDL/fre-cli/tree/c55e0620579120d8e9570128bf6e877a2d2c6867/fre/yamltools) to have `fms_yaml_tools` interface with `fre-cli`. These were not formally a dependency, however, and so those pieces of code were not tracking updates to this repository. [I removed them when I realized exactly how far behind they were](https://github.com/NOAA-GFDL/fre-cli/pull/202)...

So, after that, I set about exploring how I could make `fms_yaml_tools` a formal dependency of the `fre-cli` conda package. This PR reflects that effort! The first step to making it a formal dependency is to make `fms_yaml_tools` a conda package itself. Conda packages are only permitted to rely on other conda packages within the conda ecosystem. 

This PR is doing two main things:
1) adds `environment.yml` to create a conda environment for `fms_yaml_tools`. If one does `conda env create -f environment.yml` and activates that created environment, one should be able to clone this repo (recursively) and `pip install .` successfully into that environment. I've tested this locally by hand and it works great- the unittests pass! Additionally, there is also now `create_test_conda_env.yml`, a workflow that clearly demonstrates what `environment.yml` is for and how to use it. A successful run [can be seen here](https://github.com/ilaflott/fms_yaml_tools/actions/runs/11386994794). Aside from style/neatness, this is largely ready as a prototype approach.

2) Independent of the above capability, though slightly-overlapping, this PR also adds `meta.yaml` for initial conda packaging efforts. This is very similar to `environment.yml` but with a crucial difference- it's the target for `conda build`, which outputs a tarball that's capable of being uploaded to a conda channel repository. `fre-cli`'s workflows check the conda package build/publishing using github workflows, which i've attempted to adapt to this repo, as seen in `.github/workflows/build_conda.yml` and `.github/workflows/publish_conda.yml`. [These workflows are](https://github.com/ilaflott/fms_yaml_tools/actions/runs/11386994800) [not working yet](https://github.com/ilaflott/fms_yaml_tools/actions/runs/11386994653). I.e., the conda packaging of this repository is not ready as a prototype yet. I will detail the friction in my next comment.