### PR TITLE
Add Flake8 options to setup.cfg

### DIFF
--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -23,10 +23,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # The GitHub editor is 127 chars wide
-          flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+          flake8
       - name: Test with unittest
         run: |
           python -m unittest discover -s test

--- a/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
+++ b/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
@@ -71,21 +71,23 @@ def is_different_field(entry, new_entry, verboseprint):
     if has_outname_in:
         if not has_outname_new:
             if entry['output_name'] == entry['var_name']:
-                verboseprint("---> The output_name in entry is the same as the var_name, so the field is expected to " +
-                             "be the same")
+                verboseprint("---> The output_name in entry is the same as the var_name, so the field is expected " +
+                             "to be the same")
                 return False
 
-            verboseprint("---> Entry has output_name, but new_entry does not, so the field is not expected to be the same")
+            verboseprint("---> Entry has output_name, but new_entry does not, so the field is not expected " +
+                         "to be the same")
             return True
 
     if has_outname_new:
         if not has_outname_in:
             if new_entry['output_name'] == new_entry['var_name']:
-                verboseprint("---> The output_name in new_entry is the same as the var_name, so the field is expected to " +
-                             "be the same")
+                verboseprint("---> The output_name in new_entry is the same as the var_name, so the field is " +
+                             "expected to be the same")
                 return False
 
-            verboseprint("---> New entry has output_name, but entry does not, so the field is not expected to be the same")
+            verboseprint("---> New entry has output_name, but entry does not, so the field is not expected to " +
+                         "be the same")
             return True
 
 

--- a/fms_yaml_tools/field_table/field_table_to_yaml.py
+++ b/fms_yaml_tools/field_table/field_table_to_yaml.py
@@ -41,7 +41,8 @@ def field_to_yaml(field_table_name, debug, output_yaml, force_write):
         field-table-name - Path to the field table to convert \n
     """
     # Necessary to dump OrderedDict to yaml format
-    yaml.add_representer(OrderedDict, lambda dumper, data: dumper.represent_mapping('tag:yaml.org,2002:map', data.items()))
+    yaml.add_representer(OrderedDict, lambda dumper, data: dumper.represent_mapping('tag:yaml.org,2002:map',
+                                                                                    data.items()))
 
     if debug:
         print(field_table_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,6 @@ console_scripts =
 show-source = True
 statistics = True
 max-line-length = 120
-extend-ignore = C901
+extend-ignore = C901, E731
 per-file-ignores =
     __init__.py: F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,11 @@ console_scripts =
     is-valid-field-table-yaml = fms_yaml_tools.field_table.is_valid_field_table_yaml:validate_field_yaml
     combine-field-table-yamls = fms_yaml_tools.field_table.combine_field_table_yamls:combine_field_table_yaml
     diag-yaml-list = fms_yaml_tools.diag_table.diag_yaml_list:dyl
+
+[flake8]
+show-source = True
+statistics = True
+max-line-length = 120
+extend-ignore = C901
+per-file-ignores =
+    __init__.py: F401


### PR DESCRIPTION
* Flake8 options have been added to setup.cfg
* Maximum line length has been set to 120 characters for consistency with FMS. Lines longer than 120 characters have been broken up.
* C901 ("function is too complex") errors are ignored, as they can be a nuissance.
* E731 ("do not assign a lambda expression") errors are ignored, as a lambda assignment can sometimes make more sense than a `def`.
* F401 ("module imported but unused") errors are ignored in `__init__.py` files.