### PR TITLE
libdiagtable: Describe variables using `output_name` instead of `var_name`

### DIFF
--- a/fms_yaml_tools/diag_table/libdiagtable.py
+++ b/fms_yaml_tools/diag_table/libdiagtable.py
@@ -577,7 +577,7 @@ class DiagTableVar(DiagTableBase):
     def render(self, abstract=None):
         """Return a dictionary representation of the object"""
         if abstract and abstract.get("var"):
-            return self.var_name
+            return self.var_name if self.output_name is None else self.output_name
         else:
             var = self.strip_none()
             if "attributes" in var:


### PR DESCRIPTION
When `output_name` is available for a variable, label the variable according to its `output_name` rather than its `var_name`. This improves the readability of `diag-tool list`.