### PR TITLE
prevent errors when file does not have a diag_file

### DIFF
--- a/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
+++ b/fms_yaml_tools/diag_table/combine_diag_table_yamls.py
@@ -285,7 +285,7 @@ def combine_yaml(files, verboseprint):
         verboseprint("Attempting to get the base_date")
         get_base_date(my_table, diag_table)
 
-        diag_files = my_table['diag_files']
+        diag_files = my_table.get('diag_files', [])
         for entry in diag_files:
             check_inconsistent_keys(entry)
             if 'varlist' in entry:


### PR DESCRIPTION
`diag_files = my_table['diag_files']` does not work if the diag_files is empty
 This PR fixes that minor issue.